### PR TITLE
Add missing permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/announce-a-release.yml
+++ b/.github/workflows/announce-a-release.yml
@@ -7,6 +7,10 @@ on:
 
 concurrency: announce-a-release
 
+permissions:
+  packages: read
+  contents: write
+
 jobs:
   announce-a-release:
     name: Announce a release

--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -5,6 +5,9 @@ on:
     types:
       - shared-docker-builders-updated
 
+permissions:
+  packages: read
+
 jobs:
   vs-ponyc-latest:
     name: Verify main against ponyc latest

--- a/.github/workflows/latest-docker-image.yml
+++ b/.github/workflows/latest-docker-image.yml
@@ -9,6 +9,9 @@ concurrency:
   group: build-latest-docker-images
   cancel-in-progress: true
 
+permissions:
+  packages: write
+
 jobs:
   build-latest-docker-image:
     name: Build and push latest Docker image

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  packages: read
+
 jobs:
   x86-64-unknown-linux-nightly:
     name: Build and upload x86-64-unknown-linux-nightly to Cloudsmith

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,9 @@ concurrency:
   group: pr-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  packages: read
+
 jobs:
   superlinter:
     name: Lint bash, docker, markdown, and yaml


### PR DESCRIPTION
Adds explicit permissions blocks to workflows that were missing them, matching the standard permissions used across ponylang projects.