### PR TITLE
Add \exhaustive\ annotation to exhaustive match blocks

### DIFF
--- a/rfc-tool/main.pony
+++ b/rfc-tool/main.pony
@@ -9,7 +9,7 @@ actor Main
   new create(env: Env) =>
     _env = consume env
     try
-      match CommandParser(cli()?).parse(_env.args, _env.vars)
+      match \exhaustive\ CommandParser(cli()?).parse(_env.args, _env.vars)
       | let c: Command => run(_env.root, c)
       | let h: CommandHelp => _env.out.print(h.help_string())
       | let e: SyntaxError =>


### PR DESCRIPTION
Ponyc recently added an `\exhaustive\` annotation for match expressions. When present, the compiler will fail compilation if the match is not exhaustive. This protects against future breakage if new variants are added to a union type.

This adds `\exhaustive\` to all match blocks that are currently exhaustive and do not have an `else` clause.