### PR TITLE
Switch PR CI to ponyc nightly

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build and upload x86-64-unknown-linux-nightly to Cloudsmith
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Build and upload

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,12 +18,12 @@ permissions:
   packages: read
 
 jobs:
-  vs-ponyc-release:
-    name: Verify PR builds most recent ponyc release
+  vs-ponyc-nightly:
+    name: Verify PR builds against ponyc nightly
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Test with most recent ponyc release
+      - name: Test against ponyc nightly
         run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build and upload x86-64-unknown-linux-release to Cloudsmith
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Build and upload

--- a/corral.json
+++ b/corral.json
@@ -2,7 +2,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/peg.git",
-      "version": "0.1.5"
+      "version": "0.1.7"
     }
   ],
   "info": {}


### PR DESCRIPTION
ponyc nightly now detects exhaustive matches and treats unreachable else clauses as errors. Testing against nightly catches these issues earlier.

Note: this PR will fail CI until ponylang/peg merges the fix for its unreachable else clauses (ponylang/peg#63) and a new peg version is released. The peg dependency will need bumping after that release.