### PR TITLE
Upgrade docker/login-action to v4

### DIFF
--- a/.github/workflows/latest-docker-image.yml
+++ b/.github/workflows/latest-docker-image.yml
@@ -19,8 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
-        # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
-        # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
The v3 line of docker/login-action uses Node.js 20 which is deprecated by GitHub Actions. v4 upgrades to Node.js 24.

Updates both `latest-docker-image.yml` and `release.yml`.