### PR TITLE
Switch CI from ponyc nightly to release

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build and upload x86-64-unknown-linux-nightly to Cloudsmith
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Build and upload

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,12 +18,12 @@ permissions:
   packages: read
 
 jobs:
-  vs-ponyc-nightly:
-    name: Verify PR builds against ponyc nightly
+  vs-ponyc-release:
+    name: Verify PR builds against most recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Test against ponyc nightly
+      - name: Test against most recent ponyc release
         run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build and upload x86-64-unknown-linux-release to Cloudsmith
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Build and upload


### PR DESCRIPTION
ponyc 0.61.1 has been released. Switch CI jobs back to using the release version of ponyc.