### PR TITLE
Update release-bot-action to 0.6.4

### DIFF
--- a/.github/workflows/announce-a-release.yml
+++ b/.github/workflows/announce-a-release.yml
@@ -12,17 +12,57 @@ permissions:
   contents: write
 
 jobs:
-  announce-a-release:
-    name: Announce a release
+  announce:
+    name: Announcements
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - name: Announce
-        uses: ponylang/release-bot-action@0.3.3
+      - name: Checkout main
+        uses: actions/checkout@v6.0.2
         with:
-          step: announce-a-release
-          GIT_USER_NAME: "Ponylang Main Bot"
-          GIT_USER_EMAIL: "ponylang.main@gmail.com"
+          ref: "main"
+          token: ${{ secrets.RELEASE_TOKEN }}
+      - name: Release notes
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.4
+        with:
+          entrypoint: publish-release-notes-to-github
         env:
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          ZULIP_TOKEN: ${{ secrets.ZULIP_TOKEN }}
+      - name: Zulip
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.4
+        with:
+          entrypoint: send-announcement-to-pony-zulip
+        env:
+          ZULIP_API_KEY: ${{ secrets.ZULIP_TOKEN }}
+          ZULIP_EMAIL: ${{ secrets.ZULIP_EMAIL }}
+      - name: Last Week in Pony
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.4
+        with:
+          entrypoint: add-announcement-to-last-week-in-pony
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
+  post-announcement:
+    name: Tasks to run after the release has been announced
+    needs:
+      - announce
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: "main"
+          token: ${{ secrets.RELEASE_TOKEN }}
+      - name: Rotate release notes
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.4
+        with:
+          entrypoint: rotate-release-notes
+        env:
+          GIT_USER_NAME: "Ponylang Main Bot"
+          GIT_USER_EMAIL: "ponylang.main@gmail.com"
+      - name: Delete announcement trigger tag
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.4
+        with:
+          entrypoint: delete-announcement-tag
+        env:
+          GIT_USER_NAME: "Ponylang Main Bot"
+          GIT_USER_EMAIL: "ponylang.main@gmail.com"

--- a/.github/workflows/announce-a-release.yml
+++ b/.github/workflows/announce-a-release.yml
@@ -32,8 +32,8 @@ jobs:
         with:
           entrypoint: send-announcement-to-pony-zulip
         env:
-          ZULIP_API_KEY: ${{ secrets.ZULIP_TOKEN }}
-          ZULIP_EMAIL: ${{ secrets.ZULIP_EMAIL }}
+          ZULIP_API_KEY: ${{ secrets.ZULIP_RELEASE_API_KEY }}
+          ZULIP_EMAIL: ${{ secrets.ZULIP_RELEASE_EMAIL }}
       - name: Last Week in Pony
         uses: docker://ghcr.io/ponylang/release-bot-action:0.6.4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,23 @@ on:
 concurrency: release
 
 jobs:
+  pre-artefact-creation:
+    name: Tasks to run before artefact creation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: "main"
+          token: ${{ secrets.RELEASE_TOKEN }}
+      - name: Validate CHANGELOG
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.4
+        with:
+          entrypoint: pre-artefact-changelog-check
+
   x86-64-unknown-linux-release:
     name: Build and upload x86-64-unknown-linux-release to Cloudsmith
+    needs: [pre-artefact-creation]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
@@ -22,6 +37,7 @@ jobs:
 
   build-release-docker-images:
     name: Build and push release Docker images
+    needs: [pre-artefact-creation]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
@@ -37,14 +53,17 @@ jobs:
   trigger-release-announcement:
     name: Trigger release announcement
     runs-on: ubuntu-latest
-    needs: [x86-64-unknown-linux-release, build-release-docker-images]
+    needs: [pre-artefact-creation, x86-64-unknown-linux-release, build-release-docker-images]
     steps:
-      - uses: actions/checkout@v6.0.2
-      - name: Trigger
-        uses: ponylang/release-bot-action@0.3.3
+      - name: Checkout main
+        uses: actions/checkout@v6.0.2
         with:
-          step: trigger-release-announcement
+          ref: "main"
+          token: ${{ secrets.RELEASE_TOKEN }}
+      - name: Trigger
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.4
+        with:
+          entrypoint: trigger-release-announcement
+        env:
           GIT_USER_NAME: "Ponylang Main Bot"
           GIT_USER_EMAIL: "ponylang.main@gmail.com"
-        env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/start-a-release.yml
+++ b/.github/workflows/start-a-release.yml
@@ -7,17 +7,76 @@ on:
 
 concurrency: prepare-for-a-release
 
+permissions:
+  packages: read
+  contents: write
+
 jobs:
-  start-a-release:
-    name: Start a release
+  pre-tagging:
+    name: Tasks run before tagging the release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - name: Start
-        uses: ponylang/release-bot-action@0.3.3
+      - name: Checkout main
+        uses: actions/checkout@v6.0.2
         with:
-          step: start-a-release
+          ref: "main"
+          token: ${{ secrets.RELEASE_TOKEN }}
+      - name: Update CHANGELOG.md
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.4
+        with:
+          entrypoint: update-changelog-for-release
+        env:
           GIT_USER_NAME: "Ponylang Main Bot"
           GIT_USER_EMAIL: "ponylang.main@gmail.com"
+      - name: Update VERSION
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.4
+        with:
+          entrypoint: update-version-in-VERSION
         env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GIT_USER_NAME: "Ponylang Main Bot"
+          GIT_USER_EMAIL: "ponylang.main@gmail.com"
+      - name: Update version in corral.json
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.4
+        with:
+          entrypoint: update-version-in-corral-json
+        env:
+          GIT_USER_NAME: "Ponylang Main Bot"
+          GIT_USER_EMAIL: "ponylang.main@gmail.com"
+
+  tag-release:
+    name: Tag the release
+    needs:
+      - pre-tagging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: "main"
+          token: ${{ secrets.RELEASE_TOKEN }}
+      - name: Trigger artefact creation
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.4
+        with:
+          entrypoint: trigger-artefact-creation
+        env:
+          GIT_USER_NAME: "Ponylang Main Bot"
+          GIT_USER_EMAIL: "ponylang.main@gmail.com"
+
+  post-tagging:
+    name: Tasks run after tagging the release
+    needs:
+      - tag-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: "main"
+          token: ${{ secrets.RELEASE_TOKEN }}
+      - name: Add "unreleased" section to CHANGELOG.md
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.4
+        with:
+          entrypoint: add-unreleased-section-to-changelog
+        env:
+          GIT_USER_NAME: "Ponylang Main Bot"
+          GIT_USER_EMAIL: "ponylang.main@gmail.com"


### PR DESCRIPTION
## Context

The release workflows use `release-bot-action` at `0.3.3`, which is several major versions behind the current `0.6.4`. The `0.6.x` API removes the `step:` composite action input in favour of per-step Docker `entrypoint:` invocations, and splits the monolithic `start-a-release` and `announce-a-release` steps into granular commands.

https://github.com/ponylang/release-bot-action/blob/main/CHANGELOG.md

## Changes

- Bump `release-bot-action` from `0.3.3` to `0.6.4` across all three release workflows
- Switch invocation style from `ponylang/release-bot-action@x.y.z` with `step:` to `docker://ghcr.io/ponylang/release-bot-action:x.y.z` with `entrypoint:`
- Move `GIT_USER_NAME`/`GIT_USER_EMAIL` from `with:` to `env:`
- Expand `start-a-release` into `update-changelog-for-release`, `update-version-in-VERSION`, `update-version-in-corral-json`, `trigger-artefact-creation`, and `add-unreleased-section-to-changelog`
- Expand `announce-a-release` into `publish-release-notes-to-github`, `send-announcement-to-pony-zulip`, `add-announcement-to-last-week-in-pony`, `rotate-release-notes`, and `delete-announcement-tag`
- Add `pre-artefact-creation` job to `release.yml` that validates the CHANGELOG before artefact creation begins, gating the build and Docker image jobs on its success

Resolves #16.

## Considerations

- I've replicated the approach used in the `ponyc` repository.
- The Zulip announcement step now uses `ZULIP_RELEASE_API_KEY` and `ZULIP_RELEASE_EMAIL` (replacing the old single `ZULIP_TOKEN`). These secrets must be configured in the repo before the announce workflow will succeed.

