### PR TITLE
Stop passing the removed `--link-ldcmd` ponyc option

### DIFF
--- a/.ci-scripts/release/x86-64-unknown-linux-nightly.bash
+++ b/.ci-scripts/release/x86-64-unknown-linux-nightly.bash
@@ -87,7 +87,7 @@ ASSET_DESCRIPTION="https://github.com/${GITHUB_REPOSITORY}"
 # Build application installation
 echo -e "\e[34mBuilding ${APPLICATION_NAME}...\e[0m"
 make install prefix="${BUILD_DIR}" arch=${ARCH} \
-  version="${APPLICATION_VERSION}" static=true linker=bfd
+  version="${APPLICATION_VERSION}" static=true
 
 # Package it all up
 echo -e "\e[34mCreating .tar.gz of ${APPLICATION_NAME}...\e[0m"

--- a/.ci-scripts/release/x86-64-unknown-linux-release.bash
+++ b/.ci-scripts/release/x86-64-unknown-linux-release.bash
@@ -85,7 +85,7 @@ ASSET_DESCRIPTION="https://github.com/${GITHUB_REPOSITORY}"
 # Build application installation
 echo -e "\e[34mBuilding ${APPLICATION_NAME}...\e[0m"
 make install prefix="${BUILD_DIR}" arch=${ARCH} \
-  version="${APPLICATION_VERSION}" static=true linker=bfd
+  version="${APPLICATION_VERSION}" static=true
 
 # Package it all up
 echo -e "\e[34mCreating .tar.gz of ${APPLICATION_NAME}...\e[0m"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY rfc-tool /src/rfc-tool/rfc-tool/
 
 WORKDIR /src/rfc-tool
 
-RUN make arch=x86-64 static=true linker=bfd \
+RUN make arch=x86-64 static=true \
  && make install
 
 FROM alpine:3.18

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ prefix ?= /usr/local
 config ?= release
 arch ?=
 static ?= false
-linker ?=
 
 APPLICATION := rfc-tool
 COMPILE_WITH :=  corral run -- ponyc
@@ -38,10 +37,6 @@ endif
 
 ifeq ($(static),true)
   PONYC += --static
-endif
-
-ifneq ($(linker),)
-  PONYC += --link-ldcmd=$(linker)
 endif
 
 # Default to version from `VERSION` file but allowing overridding on the

--- a/lock.json
+++ b/lock.json
@@ -1,0 +1,8 @@
+{
+  "locks": [
+    {
+      "locator": "github.com/ponylang/peg.git",
+      "revision": "0.1.7"
+    }
+  ]
+}


### PR DESCRIPTION
ponyc removed the `--linker` and `--link-ldcmd` command line options ([ponylang/ponyc#5452](https://github.com/ponylang/ponyc/pull/5452)) — embedded LLD is now the only linker. Our Linux release builds and the Docker image build passed `linker=bfd`, which the Makefile turned into `--link-ldcmd=bfd`, so those jobs will fail with `Unrecognised option: --link-ldcmd=bfd` once they pick up the new ponyc.

That flag already had no effect on embedded LLD, so these static binaries were already being linked by it. This drops `linker=bfd` from the two Linux release scripts and the Dockerfile, and removes the Makefile `linker` option that produced the flag; the resulting binaries are unchanged.